### PR TITLE
updated bindgen

### DIFF
--- a/foundationdb-sys/Cargo.toml
+++ b/foundationdb-sys/Cargo.toml
@@ -25,4 +25,4 @@ travis-ci = { repository = "eltorocorp/foundationdb-rs" }
 
 
 [build-dependencies]
-bindgen = "0.36.1"
+bindgen = "0.51.0"

--- a/foundationdb-sys/Cargo.toml
+++ b/foundationdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foundationdb-sys"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 description = """

--- a/foundationdb/Cargo.toml
+++ b/foundationdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foundationdb"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 
 description = """


### PR DESCRIPTION
When geocoder-rs deps both moria-rs and geocoder-pxp, conflicting versions of bindgen cause the entire project to fail to build. 

Simple bindgen update solves the problem, and every test still passes.